### PR TITLE
Add error count in Beacon when sent CustomEvent

### DIFF
--- a/runtime/src/main/java/com/instana/android/core/event/models/Beacon.kt
+++ b/runtime/src/main/java/com/instana/android/core/event/models/Beacon.kt
@@ -603,7 +603,8 @@ class Beacon private constructor(
             error: String?,
             name: String
         ): Beacon {
-            return Beacon(BeaconType.CUSTOM, duration, appKey, sessionId, 0, appProfile, deviceProfile, connectionProfile, userProfile)
+            val errorCount = if (error != null) 1L else 0L
+            return Beacon(BeaconType.CUSTOM, duration, appKey, sessionId, errorCount, appProfile, deviceProfile, connectionProfile, userProfile)
                 .apply {
                     view?.run { setView(this) }
                     meta.forEach { setMeta(it.key, it.value) }


### PR DESCRIPTION
We are implementing the sending of custom events, but in the case of errors in the web platform they were not displayed as such nor were they taken by the error filter.


![Captura de Pantalla 2021-08-19 a la(s) 13 48 01](https://user-images.githubusercontent.com/24281150/130118756-1a990fe9-8ff7-4131-b6e4-59809e321bba.png)

Reviewing the sdk we saw that although the throwable is sent, it always sends the error count in 0 which affects the metrics.

The following image shows the same type of record before and after change (we test the sdk locally)

![Captura de Pantalla 2021-08-19 a la(s) 13 45 22](https://user-images.githubusercontent.com/24281150/130118370-da2dc770-a627-483a-8444-cc97324994c4.png)

