### PR TITLE
initial commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Changelog
 ==========
+## Unreleased
+
+_TBD_
+
+- Fixed duplicate network request issue in OkHttp3GlobalInterceptor
+- Added `autoRetryOnNetworkException` configuration flag to control automatic retry behavior
+- Default behavior now prevents unexpected duplicate requests by disabling automatic retries
+
 ## Version 6.2.1
 
 _2024-03-27_

--- a/runtime/src/main/java/com/instana/android/core/InstanaConfig.kt
+++ b/runtime/src/main/java/com/instana/android/core/InstanaConfig.kt
@@ -128,7 +128,14 @@ class InstanaConfig
      * If true, this option adds W3C-compliant headers to the request headers of all outgoing application requests,
      * ensuring compatibility with W3C tracing standards.
      */
-    var enableW3CHeaders: Boolean = false
+    var enableW3CHeaders: Boolean = false,
+
+    /**
+     * When enabled, automatic retries will be performed when exceptions occur during HTTP requests.
+     * When disabled, exceptions will propagate normally without retrying.
+     * Default is false to prevent unexpected duplicate requests.
+     */
+    var autoRetryOnNetworkException: Boolean = false
 ) {
 
     //This need to be provided in Performance config If the n/w analytic is need to be

--- a/runtime/src/main/java/com/instana/android/instrumentation/okhttp3/OkHttp3GlobalInterceptor.kt
+++ b/runtime/src/main/java/com/instana/android/instrumentation/okhttp3/OkHttp3GlobalInterceptor.kt
@@ -84,8 +84,15 @@ object OkHttp3GlobalInterceptor : Interceptor {
                 finish(request, e)
                 httpMarkers.remove(marker.headerValue(), marker)
             }
-            // Proceed with the original request to avoid throwing
-            chain.proceed(intercepted)
+            
+            // Only retry if the flag is enabled
+            if (Instana.config?.autoRetryOnNetworkException == true) {
+                // Proceed with the original request to retry
+                chain.proceed(intercepted)
+            } else {
+                // Otherwise rethrow the exception to let it propagate normally
+                throw e
+            }
         }
     }
 


### PR DESCRIPTION
In Instana Android agent version 6.0.23, there is an issue where requests are being duplicated. This occurs when any Exception happens during the execution of a network request, regardless of whether the request was modified by Instana itself. That is, if any interceptor generates an exception, the mechanism implemented in OkHttp3GlobalInterceptor initiates a repeat request.

2. Technical Analysis of OkHttp3GlobalInterceptor
**Purpose:** This interceptor is responsible for processing network requests, and its logic includes restarting requests when errors occur.

**Trigger Logic:** If any exception occurs during request execution, regardless of its source, the interceptor considers the request incorrectly executed and initiates a retry.
**Consequences:** A repeat request is sent even when the original request was not modified. This is not obvious to developers who may expect the logic of underlying interceptors to execute without fear of duplicate calls.
**Disruption of Expected Behavior:** Lower-level interceptors responsible for error handling may generate exceptions for incorrect HTTP codes or other issues. However, their exceptions automatically lead to request retries, which may not align with the application's logic.
**Breaking the Processing Chain:** Errors handled by lower layers are expected to be correctly propagated upward. But if an exception leads to a repeat request, this can disrupt internal error handling logic and cause duplicate actions.

**Current Implementation Problem**
The interceptor's current implementation has a catch-all exception handler that unconditionally performs a second request when any exception occurs:

My solution was to add a configurable flag in  InstanaConfig.kt
 * When enabled, automatic retries will be performed when exceptions occur during HTTP requests.
 * When disabled, exceptions will propagate normally without retrying.
 * Default is false to prevent unexpected duplicate requests.
